### PR TITLE
兼容SVG 1.1

### DIFF
--- a/lib/lib/on.js
+++ b/lib/lib/on.js
@@ -3,6 +3,11 @@ module.exports = function(element, type, handler) {
   var wrapper = function(e) {
     e = e || event;
     var arg = { target: e.target || e.srcElement };
+    // 在 SVG 1.1 中, <use>的监听器里 event.target 是 SVGElementInstance
+    // 它的 correspondingUseElement 才是元素
+    if (arg.target.correspondingUseElement) {
+      arg.target = arg.target.correspondingUseElement;
+    }
     handler.call(arg.target, arg);
   };
   if(element.addEventListener) {


### PR DESCRIPTION
Android 4.1
IE 9
等浏览器用的是SVG 1.1, 在事件监听器里 event.target 不是元素导致 error