### PR TITLE
use a sort_id for validating

### DIFF
--- a/lib/configs.js
+++ b/lib/configs.js
@@ -4,6 +4,7 @@ module.exports = {
   trackerUrl: 'https://web-ubt.ele.me/collect/log',
   // trackerUrl: 'http://localhost:3000',
   dehydratedKey: 'ubt-dehydrated-events',
+  sortIdKey: 'ubt-checking-sort-id',
   configUrl: 'https://crayfish.elemecdn.com/ubt.js@json/config',
 
   // will be overwriten by network results

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -2,6 +2,7 @@ module.exports = require('./kernel');
 
 require('./tasks/timing');
 require('./tasks/error');
+require('./tasks/sort-id');
 
 require('./events/click');
 require('./events/change');

--- a/lib/tasks/sort-id.js
+++ b/lib/tasks/sort-id.js
@@ -1,0 +1,24 @@
+
+var UBT = require('../kernel');
+var configs = require('../configs');
+
+var loopMaxNumber = 1000000;
+
+// These lines of code are for validating purpose
+// sort_id is mainly used for validating
+UBT.params.sort_id = function() {
+  var stateSortId = -1; // indicates it's a mocked value
+  try {
+    var raw = localStorage.getItem(configs.sortIdKey) || '0';
+    stateSortId = parseInt(raw, 10);
+    if (stateSortId > loopMaxNumber) {
+      stateSortId = 0;
+    } else {
+      stateSortId += 1;
+    }
+    localStorage.setItem(configs.sortIdKey, stateSortId.toString());
+  } catch (error) {
+    // localStorage might fail
+  }
+  return stateSortId;
+};

--- a/lib/tasks/sort-id.js
+++ b/lib/tasks/sort-id.js
@@ -7,14 +7,15 @@ var loopMaxNumber = 1000000;
 // These lines of code are for validating purpose
 // sort_id is mainly used for validating
 UBT.params.sort_id = function() {
-  var stateSortId = -1; // indicates it's a mocked value
+  var stateSortId = 0;
   try {
     var raw = localStorage.getItem(configs.sortIdKey) || '0';
     stateSortId = parseInt(raw, 10);
-    if (stateSortId > loopMaxNumber) {
-      stateSortId = 0;
-    } else {
+    // notice: if NaN, the condition will always be false
+    if (stateSortId <= loopMaxNumber) {
       stateSortId += 1;
+    } else {
+      stateSortId = 0;
     }
     localStorage.setItem(configs.sortIdKey, stateSortId.toString());
   } catch (error) {

--- a/lib/util/batching.js
+++ b/lib/util/batching.js
@@ -158,39 +158,7 @@ exports.startSendingLoop = function(configs) {
   window.addEventListener('beforeunload', handlePageClose);
 };
 
-// These lines of code are for validating purpose
-// sort_id is mainly used for validating
-var stateSortId = 0;
-var trackSortId = function() {
-  try {
-    var raw = localStorage.getItem(configs.sortIdKey) || '0';
-    stateSortId = parseInt(raw, 10);
-  } catch (error) {
-    // localStorage might fail
-  }
-  window.addEventListener('beforeunload', function() {
-    try {
-      localStorage.setItem(configs.sortIdKey, stateSortId.toString());
-    } catch (error) {
-      // do nothing
-    }
-  });
-};
-var loopMaxNumber = 1000000;
-var incSortId = function() {
-  if (stateSortId > loopMaxNumber) {
-    stateSortId = 0;
-  } else {
-    stateSortId += 1;
-  }
-}
-
 exports.trackEvent = function(event) {
-  incSortId();
-  event.sort_id = stateSortId;
   stateEventQueue.push(event);
   remindSendingMessage();
 };
-
-// set sort_id for checking purpose
-trackSortId();

--- a/lib/util/batching.js
+++ b/lib/util/batching.js
@@ -158,7 +158,39 @@ exports.startSendingLoop = function(configs) {
   window.addEventListener('beforeunload', handlePageClose);
 };
 
+// These lines of code are for validating purpose
+// sort_id is mainly used for validating
+var stateSortId = 0;
+var trackSortId = function() {
+  try {
+    var raw = localStorage.getItem(configs.sortIdKey) || '0';
+    stateSortId = parseInt(raw, 10);
+  } catch (error) {
+    // localStorage might fail
+  }
+  window.addEventListener('beforeunload', function() {
+    try {
+      localStorage.setItem(configs.sortIdKey, stateSortId.toString());
+    } catch (error) {
+      // do nothing
+    }
+  });
+};
+var loopMaxNumber = 1000000;
+var incSortId = function() {
+  if (stateSortId > loopMaxNumber) {
+    stateSortId = 0;
+  } else {
+    stateSortId += 1;
+  }
+}
+
 exports.trackEvent = function(event) {
+  incSortId();
+  event.sort_id = stateSortId;
   stateEventQueue.push(event);
   remindSendingMessage();
 };
+
+// set sort_id for checking purpose
+trackSortId();


### PR DESCRIPTION
一个自增的 `sort_id`, 用于服务端判断缓存在 localStorage 当中的数据传递的成功率.

稳定版本当中不会用到 `sort_id`.