### PR TITLE
版本号迭代

### DIFF
--- a/lib/configs.js
+++ b/lib/configs.js
@@ -7,7 +7,7 @@ module.exports = {
   sortIdKey: 'ubt-checking-sort-id',
   configUrl: 'https://crayfish.elemecdn.com/ubt.js@json/config',
 
-  version: '1.3.7',
+  version: '1.3.8',
 
   // will be overwriten by network results
   crayfish: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eleme-ubt",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleme-ubt",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "index": "ubt.min.js",
   "typings": "./ubt-web.d.ts",
   "scripts": {


### PR DESCRIPTION
fix: v1.3.8 的版本打包后资源在上报埋点时`version`标识还是停留在`1.3.7`